### PR TITLE
Fix off-by-one error when skipping blank-out region in cross pair scoring

### DIFF
--- a/matlab/score/calc_crossed_pair_score.m
+++ b/matlab/score/calc_crossed_pair_score.m
@@ -43,7 +43,7 @@ num_crossed_pairs  = 0;
 total_cross_res = 0;
 max_count = 0;
 for i = crossed_res
-    if i < BLANK_OUT5; continue; end;
+    if i <= BLANK_OUT5; continue; end;
     if i > length(data)-BLANK_OUT3; continue; end;
     max_count = max_count + 1;
     if data( i ) < threshold_SHAPE_fixed_pair


### PR DESCRIPTION
The impact here is very small, but is a correctness consideration

![image](https://github.com/user-attachments/assets/fc07a290-55ee-4635-b457-1b7fb3d0d502)
pearsonr=0.9999640745157865