### PR TITLE
Don't lowercase structure during sanitization

### DIFF
--- a/matlab/structure/sanitize_structure.m
+++ b/matlab/structure/sanitize_structure.m
@@ -12,7 +12,6 @@ function structure = sanitize_structure( structure, REMOVE_SINGLETS )
 % (C) R. Das, Stanford, HHMI, 2023
 if ~exist('REMOVE_SINGLETS','var') REMOVE_SINGLETS = 0; end;
 if all(structure=='x'); return; end;
-structure = lower(structure);
 structure = strrep(structure,',','');
 
 bps = convert_structure_to_bps_v3( structure);


### PR DESCRIPTION
This caused all higher-order pseudoknots represented with letters to be stripped, since we use uppercase letters to denote the closing end of the pairs