### PR TITLE
Remove redundant sanitization

### DIFF
--- a/matlab/readers/read_structure_sets_csv_file.m
+++ b/matlab/readers/read_structure_sets_csv_file.m
@@ -68,12 +68,6 @@ toc
 if sanitize_structures
     tic
     structure_sets = sanitize_structure_sets(structure_sets, structure_tags);
-    for count = 1:length(structure_sets)
-        fprintf( 'Sanitizing %d structures for %s...\n',length(structure_sets{count}),structure_tags{count});
-        for i = 1:length(structure_sets{count}) % loop over designs
-            structure_sets{count}{i} = sanitize_structure( structure_sets{count}{i} );
-        end
-    end
     toc
 end
 


### PR DESCRIPTION
`sanitize_structure_sets`, called just before, does exactly this. Removing this redundancy saves a fair amount of time