### PR TITLE
Exclude missing and failed structures from ensemble

### DIFF
--- a/matlab/score/calc_crossed_pair_score.m
+++ b/matlab/score/calc_crossed_pair_score.m
@@ -25,7 +25,6 @@ threshold_SHAPE_fixed_pair = 0.25;
 
 crossed_pair_score = 0;
 crossed_pair_quality_score = 0;
-if all(structure=='x'); return; end;
 
 % get base pairs
 bps = convert_structure_to_bps_v3(structure);

--- a/matlab/score/calc_openknot_scores.m
+++ b/matlab/score/calc_openknot_scores.m
@@ -72,11 +72,10 @@ end
 function [openknot_info_struct, eterna_classic_scores] = calc_openknot_score( r_norm, structure_sets, idx, mfe_tags, BLANK_OUT3, BLANK_OUT5, headers, make_plot, REMOVE_SINGLETS )
 
 data = r_norm(idx,:,1);
-for n = 1:length(mfe_tags)
-    structure = structure_sets{n}{idx};
-    structure = strrep(structure,'x','.');
-    if REMOVE_SINGLETS; structure_sets{n}{idx} = sanitize_structure( structure, 1); end;
-    structure_sets{n}{idx} = structure;
+if REMOVE_SINGLETS
+    for n = 1:length(mfe_tags)
+        structure_sets{n}{idx} = sanitize_structure( structure_sets{n}{idx}, 1);
+    end
 end
 structure_map_for_idx = get_structure_map( structure_sets, idx );
 
@@ -84,6 +83,7 @@ structure_map_for_idx = get_structure_map( structure_sets, idx );
 
 % eterna score classic:
 for n = 1:length(mfe_tags)
+    if isempty(structure_sets{n}{idx}); continue; end;
     pred = squeeze(structure_map_for_idx(:,:,n));
     eterna_classic_scores(n) = calc_eterna_score_classic( data, pred, BLANK_OUT5, BLANK_OUT3);
     [crossed_pair_scores(n),crossed_pair_quality_scores(n)] = calc_crossed_pair_score(data, structure_sets{n}{idx}, BLANK_OUT5, BLANK_OUT3, REMOVE_SINGLETS);

--- a/matlab/structure/sanitize_structure.m
+++ b/matlab/structure/sanitize_structure.m
@@ -11,7 +11,10 @@ function structure = sanitize_structure( structure, REMOVE_SINGLETS )
 % Requires Biers to be installed.
 % (C) R. Das, Stanford, HHMI, 2023
 if ~exist('REMOVE_SINGLETS','var') REMOVE_SINGLETS = 0; end;
-if all(structure=='x'); return; end;
+if all(structure=='x')
+    structure = '';
+    return
+end
 structure = lower(structure);
 structure = strrep(structure,',','');
 


### PR DESCRIPTION
Structures may be missing (empty string), eg because there was no target structure or failed (all `x`) because some error was encountered when running a structure prediction tool (eg, [a long-standing knotty bug](https://www.github.com/HosnaJabbari/Knotty/issues/1)). These would be treated as either all paired or all unpaired when scoring, neither of which were actually intended to be candidates (all paired may even be impossible for the sequence, as it disregards the necessity for valid pairings).

Sampling OK4/5, This largely increases scores, likely due to the ensemble including a larger amount of pseudoknotted structures (these invalid pairings could wind up scoring substantially better than alternatives, such that the ensemble contained only the invalid prediction with a CPQS of 0)
![image](https://github.com/user-attachments/assets/34851949-f972-4ac7-906f-f934726640cc)

Correlation is still quite stable, with `r=0.9804959377108586`

One edge case to note in OK4/5 is that there are 5 sequences where the nupack_pk prediction is `.`. I'm not sure where this came from, but it's not something we consider valid. In the python pipeline, we print a message when it encounters a structure of invalid length, so that the user goes back and fixes whatever the issue was. Maybe we should do something similar here?

Additionally, this does not handle the situation where the highest ECS is <5, such that extra zeros would be included in the ensemble. This seems next to impossible (and also wouldn't have much of an impact anyways) so I didn't worry about it, but if there's a better way to deal with that would be open to hearing it.